### PR TITLE
Improvements

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,14 +97,19 @@ func (m *MozProcessStat) Diff(data MozProcessStat) {
 	m.NetworkIO.Fifoout -= data.NetworkIO.Fifoout
 }
 
-// SystemInfo summarises information about the instance
-type SystemInfo struct {
+// SystemMemoryInfo summarises information about the system memory usage
+type SystemMemoryInfo struct {
 	TotalMemory      uint64  `json:"vmem_total`
+	TotalSwap        uint64  `json:"swap_total"`
 	AvailableMemory  uint64  `json:"vmem_available`
 	UsedPercent      float64 `json:"vmem_used_percent`
-	TotalSwap        uint64  `json:"swap_total"`
-	CPULogicalCount  int     `json:"cpu_logical_count"`
-	CPUPhysicalCount int     `json:"cpu_physical_count"`
+}
+
+// SystemInfo summarises information about the instance
+type SystemInfo struct {
+	MemoryStats      SystemMemoryInfo `json:"memory_stats"`
+	CPULogicalCount  int              `json:"cpu_logical_count"`
+	CPUPhysicalCount int              `json:"cpu_physical_count"`
 }
 
 // StatsOutput controls the output format of the report.
@@ -220,20 +225,22 @@ func collector(fh *os.File) {
 
 func getSystemInfo() *SystemInfo {
 	info := new(SystemInfo)
+	mem_info := new(SystemMemoryInfo)
 
 	memory, err := mem.VirtualMemory()
 	if err != nil {
 		log.Fatal(err)
 	}
-	info.TotalMemory = memory.Total
-	info.AvailableMemory = memory.Available
-	info.UsedPercent = memory.UsedPercent
+	mem_info.TotalMemory = memory.Total
+	mem_info.AvailableMemory = memory.Available
+	mem_info.UsedPercent = memory.UsedPercent
 
 	swap, err := mem.SwapMemory()
 	if err != nil {
 		log.Fatal(err)
 	}
-	info.TotalSwap = swap.Total
+	mem_info.TotalSwap = swap.Total
+	info.MemoryStats = *mem_info
 
 	cpuLogCount, err := cpu.Counts(true)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ type SystemMemoryInfo struct {
 	TotalMemory      uint64  `json:"vmem_total`
 	TotalSwap        uint64  `json:"swap_total"`
 	AvailableMemory  uint64  `json:"vmem_available`
-	UsedPercent      float64 `json:"vmem_used_percent`
+	UsedPercent      int `json:"vmem_used_percent`
 }
 
 // SystemInfo summarises information about the instance
@@ -233,7 +233,7 @@ func getSystemInfo() *SystemInfo {
 	}
 	mem_info.TotalMemory = memory.Total
 	mem_info.AvailableMemory = memory.Available
-	mem_info.UsedPercent = memory.UsedPercent
+	mem_info.UsedPercent = int(memory.UsedPercent)
 
 	swap, err := mem.SwapMemory()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -99,10 +99,12 @@ func (m *MozProcessStat) Diff(data MozProcessStat) {
 
 // SystemInfo summarises information about the instance
 type SystemInfo struct {
-	TotalMemory      uint64 `json:"vmem_total`
-	TotalSwap        uint64 `json:"swap_total"`
-	CPULogicalCount  int    `json:"cpu_logical_count"`
-	CPUPhysicalCount int    `json:"cpu_physical_count"`
+	TotalMemory      uint64  `json:"vmem_total`
+	AvailableMemory  uint64  `json:"vmem_available`
+	UsedPercent      float64 `json:"vmem_used_percent`
+	TotalSwap        uint64  `json:"swap_total"`
+	CPULogicalCount  int     `json:"cpu_logical_count"`
+	CPUPhysicalCount int     `json:"cpu_physical_count"`
 }
 
 // StatsOutput controls the output format of the report.
@@ -224,6 +226,8 @@ func getSystemInfo() *SystemInfo {
 		log.Fatal(err)
 	}
 	info.TotalMemory = memory.Total
+	info.AvailableMemory = memory.Available
+	info.UsedPercent = memory.UsedPercent
 
 	swap, err := mem.SwapMemory()
 	if err != nil {


### PR DESCRIPTION
I initially added just the `available` memory but then I thought the percent is nice to see as well since it can be consumed nicer downstream to see something like `in this instance we never saw usage of RAM going more than X% so we can downgrade the resources to Y`.